### PR TITLE
mvn clean install resulted in BUILD FAILURE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,9 @@
     <properties>
         <kafka.version>0.10.2.1</kafka.version>
         <scala.version>2.11.8</scala.version>
-        <scala.binary.version>2.11.8</scala.binary.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <!-- matches scalatest-maven-plugin version -->
+        <scalatest.version>3.0.1</scalatest.version>
     </properties>
 
     <dependencies>
@@ -36,6 +38,17 @@
             <groupId>net.liftweb</groupId>
             <artifactId>lift-json_2.11</artifactId>
             <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.liftweb</groupId>
+            <artifactId>lift-json_2.11</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>${scalatest.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -81,7 +94,7 @@
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
-                <version>1.0</version>
+                <version>2.0.0</version>
                 <configuration>
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>


### PR DESCRIPTION
mvn clean install resulted in BUILD FAILURE due to 'Error: Could not find or load main class org.scalatest.tools.Runner'. 

Bumped scalatest-maven-plugin to 2.0.0 and added scalatest deps to fix.